### PR TITLE
Fix a bug in XSpec

### DIFF
--- a/src/main/resources/xspec/compiler/generate-xspec-tests.xsl
+++ b/src/main/resources/xspec/compiler/generate-xspec-tests.xsl
@@ -205,7 +205,7 @@
                   <!-- Set up the $context variable -->
                   <xsl:apply-templates select="$context" mode="x:setup-context"/>
                   <!-- Switch to the context and call the template -->
-                  <for-each select="$context">
+                  <for-each select="$impl:context">
                     <xsl:copy-of select="$template-call" />
                   </for-each>
                 </xsl:when>


### PR DESCRIPTION
Compilation of tests using a combination of x:call[@template] and
x:context failed.

TODO: commit upsteam
