### PR TITLE
Update to daisy-parent version 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.daisy</groupId>
     <artifactId>daisy</artifactId>
-    <version>3-SNAPSHOT</version>
+    <version>3</version>
   </parent>
 
   <groupId>org.daisy.maven</groupId>


### PR DESCRIPTION
Christian wants to use xspec-maven-plugin in a project. It'd be great if you would make a release of it. We are using the SNAPSHOT but it depends on a SNAPSHOT version of daisy-parent that is not on oss.sonatype.org. So for now I changed to version 3 deployed to our local repo.
